### PR TITLE
adapt rm lib detection to repeatmast 4.1.1 (repbase replaced by dfam)

### DIFF
--- a/recipes/maker/build.sh
+++ b/recipes/maker/build.sh
@@ -13,9 +13,6 @@ perl ./Build install
 
 cd ..
 
-# Maker needs to check RepeatMasker's libraries content which are not in the expected location
-sed -i.bak 's|Libraries/RepeatMaskerLib.embl|../share/RepeatMasker/Libraries/RepeatMaskerLib.embl|g' lib/GI.pm
-
 chmod 755 bin/*
 mv bin/* $PREFIX/bin
 mkdir -p $PREFIX/perl/lib/

--- a/recipes/maker/repeatmasker_check.patch
+++ b/recipes/maker/repeatmasker_check.patch
@@ -1,11 +1,50 @@
---- lib/GI.pm	2018-06-29 20:53:50.113085044 +0200
-+++ lib/GI.pm	2018-06-29 21:04:05.041345063 +0200
-@@ -4355,7 +4355,7 @@
+--- lib/GI.pm	2014-12-01 23:37:10.000000000 +0100
++++ lib/GI.pm	2020-12-12 10:22:03.306721820 +0100
+@@ -4354,33 +4354,14 @@
+    confess "ERROR: Could not build output directory $CTL_OPT{out_base}\n"
          if(! -d $CTL_OPT{out_base});
  
-    #--make sure repbase is installed
+-   #--make sure repbase is installed
 -   if($CTL_OPT{model_org}){
++   #--make sure DFam is installed
 +   if($CTL_OPT{model_org} and !defined($ENV{'LIBDIR'})){
         my $exe = Cwd::abs_path($CTL_OPT{RepeatMasker});
         my ($lib) = $exe =~ /(.*\/)RepeatMasker$/;
-        die "ERROR: Could not determine if RepBase is installed\n" if(! $lib);
+-       die "ERROR: Could not determine if RepBase is installed\n" if(! $lib);
+-
+-       $lib .= "Libraries/RepeatMaskerLib.embl";
+-       die "ERROR: Could not determine if RepBase is installed\n" if(! -f $lib);
+-
+-       open(my $IN, "< $lib");
+-       my $rb_flag;
+-       for(my $i = 0; $i < 20; $i++){
+-           my $line = <$IN>;
+-           if($line =~ /RELEASE \d+(\-min)?\;/){
+-	       $rb_flag = ($1 && $1 eq '-min') ? 0 : 1;
+-	       last;
+-           }
+-       }
+-       close($IN);
++       die "ERROR: Could not determine if DFam is installed\n" if(! $lib);
+ 
+-       if(! $rb_flag){
+-	   warn "WARNING: RepBase is not installed for RepeatMasker. This limits\n".
+-	       "RepeatMasker's functionality and makes the model_org option in the\n".
+-	       "control files virtually meaningless. MAKER will now reconfigure\n".
+-	       "for simple repeat masking only.\n";
+-	   $CTL_OPT{model_org} = 'simple';
+-       }
++       $lib .= "../share/RepeatMasker/Libraries/RepeatMaskerLib.h5";
++       die "ERROR: Could not determine if DFam is installed\n" if(! -f $lib);
+    }
+ 
+    #--set an initialization lock so steps are locked to a single process
+@@ -4530,7 +4511,7 @@
+        print OUT "protein_gff=$O{protein_gff}  #aligned protein homology evidence from an external GFF3 file\n";
+        print OUT "\n";
+        print OUT "#-----Repeat Masking (leave values blank to skip repeat masking)\n";
+-       print OUT "model_org=$O{model_org} #select a model organism for RepBase masking in RepeatMasker\n";
++       print OUT "model_org=$O{model_org} #select a model organism for DFam masking in RepeatMasker\n";
+        print OUT "rmlib=$O{rmlib} #provide an organism specific repeat library in fasta format for RepeatMasker\n";
+        print OUT "repeat_protein=$O{repeat_protein} #provide a fasta file of transposable element proteins for RepeatRunner\n";
+        print OUT "rm_gff=$O{rm_gff} #pre-identified repeat elements from an external GFF3 file\n";


### PR DESCRIPTION
Hi @nathanweeks
Here's a modified patch which should make maker work better with repeatmasker 4.1.1 and dfam instead of repbase.
I'll make a PR for the galaxy tool to test it